### PR TITLE
feat(interop): Add `MetadataBlock` and `MetadataVoid` enums for HTML metadata elements to ensure standards compliance and separate contracts by element type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # ChangeLog
 
-## 0.2.3 Under development
+## 0.3.0 Under development
+
+- Enh #8: Add `MetadataBlock` and `MetadataVoid` enums for HTML metadata elements to ensure standards compliance and separate contracts by element type (@terabytesoftw)
 
 ## 0.2.2 January 28, 2026
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.3.x-dev"
+            "dev-main": "0.4.x-dev"
         }
     },
     "config": {

--- a/src/MetadataBlock.php
+++ b/src/MetadataBlock.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Interop;
+
+/**
+ * Represents metadata HTML elements according to the HTML standard specification.
+ *
+ * Provides a type-safe, standards-compliant set of metadata element tag names for use in element rendering, tags and
+ * view helpers.
+ *
+ * Each case corresponds to a valid metadata HTML tag as defined by the W3C and MDN documentation.
+ *
+ * Key features.
+ * - Designed for use in view, tags and components requiring metadata element structure.
+ * - Ensures technical consistency with the HTML specification and modern web standards.
+ * - Implementation of {@see BlockInterface} for contract adherence.
+ * - Integration-ready for tag rendering and element generation APIs.
+ * - Strict mapping of metadata HTML tags for semantic markup generation.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Content_categories#metadata_content
+ * {@see BlockInterface} for contract details.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum MetadataBlock: string implements BlockInterface
+{
+    /**
+     * Case for the `<noscript>` HTML tag.
+     *
+     * Categorized as metadata, flow, and phrasing content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/noscript
+     */
+    case NOSCRIPT = 'noscript';
+
+    /**
+     * Case for the `<script>` HTML tag.
+     *
+     * Categorized as metadata, flow, and phrasing content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script
+     */
+    case SCRIPT = 'script';
+
+    /**
+     * Case for the `<style>` HTML tag.
+     *
+     * Categorized as metadata content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style
+     */
+    case STYLE = 'style';
+
+    /**
+     * Case for the `<template>` HTML tag.
+     *
+     * Categorized as metadata, flow, and phrasing content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template
+     */
+    case TEMPLATE = 'template';
+
+    /**
+     * Case for the `<title>` HTML tag.
+     *
+     * Categorized as metadata content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/title
+     */
+    case TITLE = 'title';
+}

--- a/src/MetadataVoid.php
+++ b/src/MetadataVoid.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Interop;
+
+/**
+ * Represents metadata HTML elements according to the HTML standard specification.
+ *
+ * Provides a type-safe, standards-compliant set of metadata element tag names for use in element rendering, tags and
+ * view helpers.
+ *
+ * Each case corresponds to a valid metadata HTML tag as defined by the W3C and MDN documentation.
+ *
+ * Key features.
+ * - Designed for use in view, tags and components requiring metadata element structure.
+ * - Ensures technical consistency with the HTML specification and modern web standards.
+ * - Implementation of {@see VoidInterface} for contract adherence.
+ * - Integration-ready for tag rendering and element generation APIs.
+ * - Strict mapping of metadata HTML tags for semantic markup generation.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Content_categories#metadata_content
+ * {@see VoidInterface} for contract details.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum MetadataVoid: string implements VoidInterface
+{
+    /**
+     * Case for the `<base>` HTML tag.
+     *
+     * Categorized as metadata content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/base
+     */
+    case BASE = 'base';
+
+    /**
+     * Case for the `<link>` HTML tag.
+     *
+     * Categorized as metadata content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link
+     */
+    case LINK = 'link';
+
+    /**
+     * Case for the `<meta>` HTML tag.
+     *
+     * Categorized as metadata content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta
+     */
+    case META = 'meta';
+}

--- a/src/Voids.php
+++ b/src/Voids.php
@@ -37,15 +37,6 @@ enum Voids: string implements VoidInterface
     case AREA = 'area';
 
     /**
-     * Case for the `<base>` HTML tag.
-     *
-     * Categorized as metadata content.
-     *
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/base
-     */
-    case BASE = 'base';
-
-    /**
      * Case for the `<br>` HTML tag.
      *
      * Categorized as flow, palpable, phrasing content.
@@ -96,24 +87,6 @@ enum Voids: string implements VoidInterface
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input
      */
     case INPUT = 'input';
-
-    /**
-     * Case for the `<link>` HTML tag.
-     *
-     * Categorized as metadata content.
-     *
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link
-     */
-    case LINK = 'link';
-
-    /**
-     * Case for the `<meta>` HTML tag.
-     *
-     * Categorized as metadata content.
-     *
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta
-     */
-    case META = 'meta';
 
     /**
      * Case for the `<param>` HTML tag.


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added type-safe enums for HTML metadata block elements (noscript, script, style, template, title) and void elements (base, link, meta), improving standards compliance and element organization.

* **Chores**
  * Version bumped to 0.3.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->