### PR TITLE
fix(interop): Move `H1 - H6` classes from `Block` to `Inline` class to better reflect their usage in HTML structure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # ChangeLog
 
-## 0.3.1 Under development
+## 0.4.0 Under development
+
+- Bug #10: Move `H1 - H6` classes from `Block` to `Inline` class to better reflect their usage in HTML structure (@terabytesoftw)
 
 ## 0.3.0 January 29, 2026
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.4.x-dev"
+            "dev-main": "0.5.x-dev"
         }
     },
     "config": {

--- a/src/Block.php
+++ b/src/Block.php
@@ -161,60 +161,6 @@ enum Block: string implements BlockInterface
     case FORM = 'form';
 
     /**
-     * Case for the `<h1>` HTML tag.
-     *
-     * Categorized as flow, heading, and palpable content.
-     *
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements
-     */
-    case H1 = 'h1';
-
-    /**
-     * Case for the `<h2>` HTML tag.
-     *
-     * Categorized as flow, heading, and palpable content.
-     *
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements
-     */
-    case H2 = 'h2';
-
-    /**
-     * Case for the `<h3>` HTML tag.
-     *
-     * Categorized as flow, heading, and palpable content.
-     *
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements
-     */
-    case H3 = 'h3';
-
-    /**
-     * Case for the `<h4>` HTML tag.
-     *
-     * Categorized as flow, heading, and palpable content.
-     *
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements
-     */
-    case H4 = 'h4';
-
-    /**
-     * Case for the `<h5>` HTML tag.
-     *
-     * Categorized as flow, heading, and palpable content.
-     *
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements
-     */
-    case H5 = 'h5';
-
-    /**
-     * Case for the `<h6>` HTML tag.
-     *
-     * Categorized as flow, heading, and palpable content.
-     *
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements
-     */
-    case H6 = 'h6';
-
-    /**
      * Case for the `<header>` HTML tag.
      *
      * Categorized as flow and palpable content.

--- a/src/Inline.php
+++ b/src/Inline.php
@@ -127,6 +127,60 @@ enum Inline: string implements InlineInterface
     case EM = 'em';
 
     /**
+     * Case for the `<h1>` HTML tag.
+     *
+     * Categorized as flow, heading, and palpable content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements
+     */
+    case H1 = 'h1';
+
+    /**
+     * Case for the `<h2>` HTML tag.
+     *
+     * Categorized as flow, heading, and palpable content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements
+     */
+    case H2 = 'h2';
+
+    /**
+     * Case for the `<h3>` HTML tag.
+     *
+     * Categorized as flow, heading, and palpable content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements
+     */
+    case H3 = 'h3';
+
+    /**
+     * Case for the `<h4>` HTML tag.
+     *
+     * Categorized as flow, heading, and palpable content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements
+     */
+    case H4 = 'h4';
+
+    /**
+     * Case for the `<h5>` HTML tag.
+     *
+     * Categorized as flow, heading, and palpable content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements
+     */
+    case H5 = 'h5';
+
+    /**
+     * Case for the `<h6>` HTML tag.
+     *
+     * Categorized as flow, heading, and palpable content.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements
+     */
+    case H6 = 'h6';
+
+    /**
      * Case for the `<i>` HTML tag.
      *
      * Categorized as flow, palpable, and phrasing content.


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reclassified HTML heading elements (H1–H6) for improved HTML structure alignment.

* **Chores**
  * Updated version to 0.4.0.
  * Updated development version to 0.5.x-dev.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->